### PR TITLE
feat: 添加 GraalVM原生编译支持 并 优化构建配置

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release CLI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  native:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+        include:
+          - os: ubuntu-latest
+            artifact: pack2server-linux-amd64
+          - os: windows-latest
+            artifact: pack2server-windows-amd64.exe
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '21'
+          distribution: 'graalvm-community'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '9'
+          build-cache-push: true
+          build-cache-enabled: true
+          dependency-graph: generate-and-submit
+
+      - name: Build & Native Image
+        run: ./gradlew build nativeCompile --configuration-cache --build-cache --scan
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            build/native/nativeCompile/pack2server*
+            build/libs/*-cli.jar
+      - name: Generate provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: 'build/native/nativeCompile/pack2server*'
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/native/nativeCompile/pack2server*
+            build/libs/*-cli.jar
+          generate_release_notes: true
+          append_body: |
+            ## Verification
+            - **SBOM & provenance**: 见下方 attestations
+            - **Checksums**: 已内置于 Release 文件

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ pack2server/
 
 ```bash
 # 构建项目
-./gradlew shadowJar
+./gradlew build
+./gradlew nativeCompile
 
 # 运行测试
 ./gradlew test

--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ pack2server/
 
 ```bash
 # 构建项目
-./gradlew build
-./gradlew nativeCompile
+./gradlew build nativeCompile
 
 # 运行测试
 ./gradlew test

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 plugins {
     id "java"
     id "com.gradleup.shadow" version "9.1.0"
@@ -9,8 +11,8 @@ version = "0.9"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
         vendor = JvmVendorSpec.ORACLE
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -29,6 +31,7 @@ ext {
     lombokVersion = "1.18.38"
     picocliVersion = "4.7.7"
     jsonpathVersion = "2.9.0"
+    lombokCAVersion = "0.2.0"
     compressVersion = "1.28.0"
     junitJupiterVersion = "5.13.4"
 }
@@ -49,6 +52,7 @@ dependencies {
     // ========== lombok ==========
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok-mapstruct-binding:${lombokCAVersion}"
     // ========== junit jupiter ==========
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testImplementation "org.junit.jupiter:junit-jupiter:${junitJupiterVersion}"
@@ -56,16 +60,16 @@ dependencies {
 }
 
 shadowJar {
-    mergeServiceFiles()
+    archiveVersion = ''
+    archiveClassifier = 'cli'
+    archiveBaseName = 'pack2server'
     manifest {
-        archiveVersion = ''
-        archiveClassifier = 'run'
-        archiveBaseName = 'pack2server'
         attributes(
                 'Main-Class': "${project.group}.Pack2server",
                 'Implementation-Version': project.version
         )
     }
+    mergeServiceFiles()
 }
 
 graalvmNative {
@@ -78,9 +82,26 @@ graalvmNative {
                 '--gc=serial',
                 '--no-fallback',
                 '-march=native',
+                '-H:+CompactObjectHeaders',
+                '-H:±UseCompressedReferences',
+                '-H:-PrintRuntimeCompileMethods',
                 '-H:+ReportExceptionStackTraces',
-                '--enable-url-protocols=http,https'
+                '--enable-url-protocols=http,https',
+                '-H:MissingRegistrationReportingMode=error',
+                '-H:ThrowMissingRegistrationErrors=reflection,proxy,jni',
+                '--initialize-at-build-time=cn.hutool.core.date.DateUtil,cn.hutool.core.util.StrUtil,org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream'
         )
+        if (DefaultNativePlatform.currentOperatingSystem.isLinux()) {
+            buildArgs.add('-H:+StaticExecutableWithDynamicLibC')
+        }
+    }
+    agent {
+        defaultMode = 'standard'
+        metadataCopy {
+            inputTaskNames.add('run')
+            mergeWithExisting = Boolean.TRUE
+            outputDirectories.add('src/main/resources/META-INF/native-image')
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,16 @@
 plugins {
     id "java"
     id "com.gradleup.shadow" version "9.1.0"
+    id "org.graalvm.buildtools.native" version "0.11.0"
 }
 
 group = "cloud.dbug.pack2server"
-version = "0.8"
+version = "0.9"
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
+        vendor = JvmVendorSpec.ORACLE
     }
 }
 
@@ -57,18 +59,35 @@ shadowJar {
     mergeServiceFiles()
     manifest {
         archiveVersion = ''
-        archiveClassifier = ''
+        archiveClassifier = 'run'
         archiveBaseName = 'pack2server'
         attributes(
                 'Main-Class': "${project.group}.Pack2server",
-                'Implementation-Version': project.version,
-                'Created-By': "Gradle ${gradle.gradleVersion} + UTF-8"
+                'Implementation-Version': project.version
+        )
+    }
+}
+
+graalvmNative {
+    toolchainDetection = Boolean.FALSE
+    binaries.main {
+        imageName = 'pack2server'
+        mainClass = "${group}.Pack2server"
+        buildArgs.addAll(
+                '-O3',
+                '--gc=serial',
+                '--no-fallback',
+                '-march=native',
+                '-H:+ReportExceptionStackTraces',
+                '--enable-url-protocols=http,https'
         )
     }
 }
 
 test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags 'local'
+    }
     failOnNoDiscoveredTests = Boolean.FALSE
     systemProperties = [
             'junit.jupiter.execution.parallel.enabled'                 : Boolean.TRUE,
@@ -80,10 +99,7 @@ test {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
-}
-
-tasks.named("check") {
-    dependsOn.removeAll { it.name == "test" }
+    options.compilerArgs += ['-Xlint:deprecation', '-Xlint:unchecked']
 }
 
 tasks.register("printVersion") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-# \u5B88\u62A4\u3001\u7F13\u5B58\u3001\u5E76\u884C\u3001\u589E\u91CF\u3001\u89C2\u5BDF
+# \u5B88\u62A4\u3001\u7F13\u5B58\u3001\u5E76\u884C\u3001\u589E\u91CF\u3001\u89C2\u5BDF\u3001\u7F16\u8BD1
 org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true
@@ -6,6 +6,9 @@ org.gradle.vfs.watch=true
 org.gradle.incremental=true
 org.gradle.parallel-test=true
 org.gradle.configureondemand=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+org.gradle.java.compile-classpath-packaging=true
 # \u65E5\u5FD7\u7EA7\u522B\uFF08\u4E00\u822C\u8D8A\u5C0F\u8D8A\u597D\uFF0C\u9664\u975E\u8981\u8C03\u8BD5gradle\uFF09
 org.gradle.logging.level=lifecycle
 # \u6700\u5927\u5DE5\u4F5C\u7EBF\u7A0B\u6570\uFF08\u6309\u9700\u914D\u7F6E\u4E00\u822C\u6839\u636Ecpu\u6570\u91CF\uFF09

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,4 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
 rootProject.name = 'pack2server'

--- a/src/test/java/cloud/dbug/pack2server/DownloaderTest.java
+++ b/src/test/java/cloud/dbug/pack2server/DownloaderTest.java
@@ -1,5 +1,6 @@
 package cloud.dbug.pack2server;
 
+import cloud.dbug.pack2server.annotation.LocalOnly;
 import cloud.dbug.pack2server.common.ServerWorkspace;
 import cloud.dbug.pack2server.common.downloader.Downloader;
 import cn.hutool.core.io.FileUtil;
@@ -13,6 +14,7 @@ import java.util.List;
  * @author 拒绝者
  * @date 2025-09-05
  */
+@LocalOnly
 public class DownloaderTest {
     @Test
     @DisplayName("单个下载")

--- a/src/test/java/cloud/dbug/pack2server/ServerFileTest.java
+++ b/src/test/java/cloud/dbug/pack2server/ServerFileTest.java
@@ -1,5 +1,6 @@
 package cloud.dbug.pack2server;
 
+import cloud.dbug.pack2server.annotation.LocalOnly;
 import cloud.dbug.pack2server.common.ServerWorkspace;
 import cloud.dbug.pack2server.common.detector.ServerModDetector;
 import cloud.dbug.pack2server.common.detector.enums.Side;
@@ -41,6 +42,7 @@ import java.util.stream.Stream;
  * @author 拒绝者
  * @since 2025-09-06
  */
+@LocalOnly
 public class ServerFileTest {
     @Test
     @DisplayName("解压原始模组包")

--- a/src/test/java/cloud/dbug/pack2server/annotation/LocalOnly.java
+++ b/src/test/java/cloud/dbug/pack2server/annotation/LocalOnly.java
@@ -1,0 +1,19 @@
+package cloud.dbug.pack2server.annotation;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 仅限本地
+ * @author 拒绝者
+ * @date 2025-09-07
+ */
+@Tag("local")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface LocalOnly {
+}


### PR DESCRIPTION
- 引入 GraalVM Build Tools 插件，支持原生编译
- 更新构建脚本，增加 nativeCompile 任务
- 调整 jar 包构建配置，设置主类和相关属性
- 添加新测试注解 @localonly，用于标记仅限本地运行的测试
- 更新 README，添加原生编译构建说明
- 优化测试配置，排除本地测试