### PR TITLE
ci(release): 更新 Gradle版本并调整相关配置

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
 
       - name: Setup GraalVM
         uses: graalvm/setup-graalvm@v1
@@ -35,7 +37,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '9'
+          gradle-version: '9.0.0'
           build-cache-push: true
           build-cache-enabled: true
           dependency-graph: generate-and-submit

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,8 @@
 .gradle
 build/
 Temp/
-!gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-gradle-wrapper.jar
 
 ### IntelliJ IDEA ###
 .idea

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.workers.max=20
 # JVM\u914D\u7F6E\uFF08\u6309\u9700\u914D\u7F6E\u4E00\u822C\u6839\u636E\u673A\u5668\u5185\u5B58\u4E0E\u9879\u76EE\u6587\u4EF6\u6570\u91CF\uFF09
 org.gradle.jvmargs=-Xms1g -Xmx5g -XX:MaxMetaspaceSize=1g -Xshare:off -Djava.security.manager=allow -XX:+HeapDumpOnOutOfMemoryError -Duser.timezone=GMT+8 -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8
 # \u8BBE\u7F6E HTTP \u4EE3\u7406\uFF08\u5982\u679C\u9700\u8981\uFF09
-#systemProp.http.proxyHost=127.0.0.1
-#systemProp.http.proxyPort=7897
-#systemProp.https.proxyHost=127.0.0.1
-#systemProp.https.proxyPort=7897
+systemProp.http.proxyHost=127.0.0.1
+systemProp.http.proxyPort=7897
+systemProp.https.proxyHost=127.0.0.1
+systemProp.https.proxyPort=7897


### PR DESCRIPTION
- 将 Gradle 版本更新为 9.0.0
- 添加使 gradlew 可执行的步骤
- 更新 .gitignore 文件，移除对 gradle-wrapper.jar 的排除
- 在 gradle.properties 中启用 HTTP 代理设置